### PR TITLE
Add Jupyter Notebook to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ These models are not vetted for accuracy nor propriety and should not be deploye
 
 ## Requirements
 
-- JupyterLab >= 4.1.0 (not yet released)
+- JupyterLab >= 4.1.0 or Jupyter Notebook >= 7.1.0 (not yet released)
 - A browser supporting:
   - [`SharedArrayBuffer`](https://caniuse.com/sharedarraybuffer)
   - [Web Workers](https://caniuse.com/webworkers)


### PR DESCRIPTION
Testing on https://github.com/jupyter/notebook/pull/7161 it looks like the inline completion should also work nicely in Notebook 7:

https://github.com/krassowski/jupyterlab-transformers-completer/assets/591645/e2c6207a-278c-4339-86fe-e0932c3eb7c5

This is not yet released in a `7.1.0` pre-release but will be soon.