### PR TITLE
Use `credentialless` over `require-corp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,13 @@ These models are not vetted for accuracy nor propriety and should not be deploye
 - `jupyter-server` to enable additional headers (`jupyverse` and `jupyterlite` not tested yet)
 
 When this extension is enabled, the server will return additional headers,
-which will prevent fetching external resources, for example the extension logos
-from GitHub will no longer load in the extension panel.
+which may limit fetching external resources.
 
 The additional headers are used to enable synchronous communication with WebWorker via `SharedArrayBuffer`:
 
 ```http
 Cross-Origin-Opener-Policy: same-origin,
-Cross-Origin-Embedder-Policy: require-corp
+Cross-Origin-Embedder-Policy: credentialless
 ```
 
 ## Install

--- a/jupyterlab_transformers_completer/__init__.py
+++ b/jupyterlab_transformers_completer/__init__.py
@@ -34,7 +34,7 @@ def _load_jupyter_server_extension(server_app):
     server_app.web_app.settings["headers"].update({
       # Allow access to `SharedArrayBuffer`.
       "Cross-Origin-Opener-Policy": "same-origin",
-      "Cross-Origin-Embedder-Policy": "require-corp",
+      "Cross-Origin-Embedder-Policy": "credentialless",
     })
     name = "@jupyterlab/transformers-completer"
     server_app.log.info(f"Registered {name} server extension")


### PR DESCRIPTION
This makes the extension images and other external resources load (as long as credentials are not required to load them).

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy

Downside: not yet supported by Safari https://bugs.webkit.org/show_bug.cgi?id=230550