### PR TITLE
Upgrade transformers.js to v2.17.1, add two text models

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jupyterlab/transformers-completer",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Inline completion provider using tranformers.js for JupyterLab.",
     "keywords": [
         "jupyter",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "dependencies": {
         "@jupyterlab/application": "^4.1.0",
         "@jupyterlab/completer": "^4.1.0",
-        "@xenova/transformers": "~2.6.2"
+        "@xenova/transformers": "~2.17.1"
     },
     "devDependencies": {
         "@jupyterlab/builder": "^4.1.0",

--- a/src/models.ts
+++ b/src/models.ts
@@ -82,5 +82,13 @@ export const textModels: IModelInfo[] = [
   {
     repo: 'Xenova/llama-160m',
     licence: 'other'
+  },
+  {
+    repo: 'Xenova/Qwen1.5-0.5B-Chat',
+    licence: 'tongyi-qianwen-research'
+  },
+  {
+    repo: 'Xenova/bloom-560m',
+    licence: 'bigscience-bloom-rail-1.0'
   }
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -384,6 +384,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@huggingface/jinja@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "@huggingface/jinja@npm:0.2.2"
+  checksum: 8a6e3e287863d437920990afa2ca25d83c51997bd5ba0325ea90633e52469c2d901178cbd758cc362b45ad1c9521fccf372884fd59e58d2916d6b2e5bb15f776
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.11.11":
   version: 0.11.11
   resolution: "@humanwhocodes/config-array@npm:0.11.11"
@@ -902,7 +909,7 @@ __metadata:
     "@types/react": ^18.0.26
     "@typescript-eslint/eslint-plugin": ^6.1.0
     "@typescript-eslint/parser": ^6.1.0
-    "@xenova/transformers": ~2.6.2
+    "@xenova/transformers": ~2.17.1
     css-loader: ^6.7.1
     eslint: ^8.36.0
     eslint-config-prettier: ^8.8.0
@@ -1895,17 +1902,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xenova/transformers@npm:~2.6.2":
-  version: 2.6.2
-  resolution: "@xenova/transformers@npm:2.6.2"
+"@xenova/transformers@npm:~2.17.1":
+  version: 2.17.1
+  resolution: "@xenova/transformers@npm:2.17.1"
   dependencies:
+    "@huggingface/jinja": ^0.2.2
     onnxruntime-node: 1.14.0
     onnxruntime-web: 1.14.0
     sharp: ^0.32.0
   dependenciesMeta:
     onnxruntime-node:
       optional: true
-  checksum: 025cd9b7fb6d281c9c58d08e0228236005d7733dc1b4855088178a9903124ace5aed92c2979d01325141f76bd9d267de519d3149dd67c824de300cf4366350c6
+  checksum: ff99a95268555d69bb67eb9ea494aced915c2de75973967f74bcc5fe0c7bd490bd3bb40a2906cd34007dcb4f5cb847ed3cde63beef25069f6af0e328fe3b23b6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrades `@xenova/transformers` to v2.17.1

Adds `Xenova/Qwen1.5-0.5B-Chat` and `Xenova/bloom-560m` text models.